### PR TITLE
feature/login annotation

### DIFF
--- a/blog/gradle/wrapper/gradle-wrapper.properties
+++ b/blog/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/blog/src/main/java/cloudclub/blog/global/LoginUserArgumentResolver.java
+++ b/blog/src/main/java/cloudclub/blog/global/LoginUserArgumentResolver.java
@@ -1,0 +1,37 @@
+package cloudclub.blog.global;
+
+import cloudclub.blog.global.annotation.LoginInfo;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(LoginInfo.class) != null;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+        ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+        WebDataBinderFactory binderFactory) throws Exception {
+        Principal principal = SecurityContextHolder.getContext().getAuthentication();
+
+        if (principal.getName().equals("anonymousUser")) {
+            throw new Exception("로그인이 필요합니다.");
+        }
+
+        return principal.getName();
+    }
+}

--- a/blog/src/main/java/cloudclub/blog/global/annotation/LoginInfo.java
+++ b/blog/src/main/java/cloudclub/blog/global/annotation/LoginInfo.java
@@ -1,0 +1,11 @@
+package cloudclub.blog.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginInfo {
+}

--- a/blog/src/main/java/cloudclub/blog/global/config/LoginConfig.java
+++ b/blog/src/main/java/cloudclub/blog/global/config/LoginConfig.java
@@ -1,0 +1,19 @@
+package cloudclub.blog.global.config;
+
+import cloudclub.blog.global.LoginUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class LoginConfig implements WebMvcConfigurer {
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(loginUserArgumentResolver);
+    }
+}

--- a/blog/src/main/java/cloudclub/blog/users/controller/UserController.java
+++ b/blog/src/main/java/cloudclub/blog/users/controller/UserController.java
@@ -1,5 +1,6 @@
 package cloudclub.blog.users.controller;
 
+import cloudclub.blog.global.annotation.LoginInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -18,5 +19,10 @@ public class UserController {
     @ResponseBody
     public String healthCheck(Principal principal) {
         return principal.getName();
+    }
+    @GetMapping("/annotation")
+    @ResponseBody
+    public String healthCheckAnnotation(@LoginInfo String userId) {
+        return userId;
     }
 }


### PR DESCRIPTION
일단 로그인 어노테이션을 추가했습니다.

기본적인 사용법은 다음과 같습니다.
```java
@GetMapping("/annotation")
    @ResponseBody
    public String healthCheckAnnotation(@LoginInfo String userId) {
        return userId;
    }
```
이런식으로 https://github.com/logininfo 어노테이션을 쓰고 뒤에 인자를 배치하면 로그인한 유저의 email을 jwt 토큰으로 부터 가져올 수 있습니다.

원리는 LoginUserArgumentResolver 에서 파라미터와 인자를 가져와서 처리하는 방식으로 진행됩니다.